### PR TITLE
fixes issue with non-ascii chars in customer

### DIFF
--- a/tests/customer_tests.py
+++ b/tests/customer_tests.py
@@ -1,5 +1,5 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014 Michael Rice <michael@michaelrice.org>
-#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
@@ -11,6 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+
+from __future__ import unicode_literals
 
 import vcr
 
@@ -129,3 +131,13 @@ class CustomerTests(tests.VCRBasedTests):
         customer_id = 10
         updated_customer = customers.update_customer(tests.CONNECTION, customer_id, customer_info)
         self.assertIsInstance(updated_customer, dict)
+
+    def test_customer_builder(self):
+        customer = {
+            'country': 'US',
+            'name': '¿Cómo',
+            'postal_code': '78555'
+        }
+        xml = customers._build_customer_payload(customer)
+        res = b'<customer xmlns="http://www.vmware.com/UM"><name>&#191;C&#243;mo</name><country>US</country><postalCode>78555</postalCode></customer>'
+        self.assertEqual(xml, res)

--- a/thunderhead/builder/customers.py
+++ b/thunderhead/builder/customers.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2014 Michael Rice <michael@michaelrice.org>
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+
+from __future__ import unicode_literals
 
 from xml.etree.ElementTree import Element
 from xml.etree.ElementTree import SubElement
@@ -81,6 +84,15 @@ def _build_customer_payload(customer):
         <country>US</country>
         <postalCode>90210</postalCode>
     </customer>
+
+    >>> foo = "¿Cómo"
+    >>> attribs = { 'xmlns': 'http://www.vmware.com/UM' }
+    >>> root = Element('vcServer', attribs)
+    >>> host = SubElement(root, 'hostname')
+    >>> host.text = foo.decode(encoding='utf8')
+    >>> tostring(root)
+        '<vcServer xmlns="http://www.vmware.com/UM"><hostname>&#191;C&#243;mo</hostname></vcServer>'
+
     """
     if not 'country' in customer:
         raise MissingProperty("Missing required 'country'.")
@@ -94,11 +106,11 @@ def _build_customer_payload(customer):
     }
     root = Element('customer', attribs)
     name = SubElement(root, 'name')
-    name.text = str(customer['name'])
+    name.text = customer['name']
     country = SubElement(root, 'country')
     country.text = customer['country']
     postal = SubElement(root, 'postalCode')
-    postal.text = str(customer['postal_code'])
+    postal.text = customer['postal_code']
     return tostring(root)
 
 


### PR DESCRIPTION
This fix adds support for non ascii names in customers
by doing a decode utf8 on the strings. fixes #25
