### PR TITLE
Skip SSL cert validation in get_report() if Connection.verify_ssl is False

### DIFF
--- a/thunderhead/builder/reports.py
+++ b/thunderhead/builder/reports.py
@@ -38,7 +38,8 @@ def get_report(connection, report_id, date_from, date_to):
         'dateTo': date_to
     }
     url = connection.build_url()
-    res = requests.get(url, headers=extra_headers, params=query_params)
+    verify_ssl = connection.verify_ssl
+    res = requests.get(url, headers=extra_headers, params=query_params, verify=verify_ssl)
     if res.status_code == 200:
         return res.content
     raise ReportException("Error fetching report: {0} => {1}".format(


### PR DESCRIPTION
Currently it is not possible to use a self signed cert with `get_report()`. This PR fixes that.